### PR TITLE
an option to keep all columns from logs

### DIFF
--- a/R/cran.stats.R
+++ b/R/cran.stats.R
@@ -1,5 +1,5 @@
 ## exported functions
-read_logs <- function(start, end, path="./", dir="cran-mirror", verbose=TRUE) {
+read_logs <- function(start, end, path="./", dir="cran-mirror", verbose=TRUE, select=c("date", "time", "package", "country", "ip_id")) {
     
     if (class(start) != "Date") {
         warning("Coercing 'start' to Date class")
@@ -11,7 +11,7 @@ read_logs <- function(start, end, path="./", dir="cran-mirror", verbose=TRUE) {
     }
     urls = urls_(seq(start, end, by="days"))
     odir = file.path(path, dir)
-    read_logs_(urls, odir, verbose)
+    read_logs_(urls, odir, verbose, select = select)
 }
 
 stats_logs <- function(dt, type="monthly", packages=c("data.table"), dependency=TRUE, duration=30L) {
@@ -144,14 +144,13 @@ unzip_logs <- function(urls, path, rec=1L, verbose=TRUE) {
     invisible(NULL)
 }
 
-fread_logs <- function(urls, path, verbose=TRUE) {
+fread_logs <- function(urls, path, verbose=TRUE, select=c("date", "time", "package", "country", "ip_id")) {
     idx  = match_(urls, path, regex="\\.gz$", pattern="\\.csv$", reverse=TRUE)
     dest = file.path(path, list.files(path, pattern="\\.csv$")[idx])
     tot  = length(dest)
-    sel  = c("date", "time", "package", "country", "ip_id")
     ans  = lapply(seq_along(dest), function(i){
         if (verbose) verbose_("Fread(ing) logs   ", i, tot, basename(dest[i]))
-        fread(dest[i], select=sel)
+        fread(dest[i], select=select)
     })
     ans = rbindlist(ans)
     keycols = c("package", "date", "time")
@@ -159,10 +158,10 @@ fread_logs <- function(urls, path, verbose=TRUE) {
     setcolorder(ans, c(keycols, setdiff(names(ans), keycols)))
 }
 
-read_logs_ <- function(urls, odir, verbose) {
+read_logs_ <- function(urls, odir, verbose, select=c("date", "time", "package", "country", "ip_id")) {
     download_logs(urls, odir, verbose)
     unzip_logs(urls, odir, 1L, verbose)
-    fread_logs(urls, odir, verbose)
+    fread_logs(urls, odir, verbose, select = select)
 }
 
 yearly  = function(x) { gsub("^(.*)-(.*)-(.*)$", "\\1", x, perl=TRUE) }

--- a/man/read_logs.Rd
+++ b/man/read_logs.Rd
@@ -13,6 +13,7 @@ read_logs(start, end, path="./", dir="cran-mirror", verbose=TRUE)
   \item{path}{ Path excluding the directory to download logs to}
   \item{dir}{ Directory within \code{path} where the logs will be downloaded to }
   \item{verbose}{ \code{TRUE} provides informative messages to the console }
+  \item{select}{ character vector of column names to keep from the logs, by default \code{c("date", "time", "package", "country", "ip_id")}}
 }
 \details{
     \code{read_logs} creates a folder under the path \code{path/dir} and downloads the logs from the date \code{start} until \code{end} on to it. After downloading all the logs, they will be automatically replaced with corresponding unzipped versions. If an unzipped log already exists, then download of that log will be skipped. If a log that was downloaded was corrupted, it'll be deleted autmatically and will be attemped again for download+unzip. If it fails again, the download of that log will be skipped.


### PR DESCRIPTION
allows to keep all columns, by default it use columns used by you originally.

``` r
library(data.table)
library(cran.stats)
all.cols = c("date","time","size","r_version","r_arch","r_os","package","version","country","ip_id")
dt = read_logs(start = as.Date("2014-07-01"), 
               end = as.Date("2014-07-31"), 
               dir = "cran-mirror", 
               verbose = TRUE,
               select = all.cols)
tail(dt, 2)
#   package       date     time  size r_version r_arch    r_os version country ip_id
#1:     zyp 2014-07-31 20:04:32 28152     3.1.1   i386 mingw32  0.10-1      PE 10177
#2:     zyp 2014-07-31 20:43:58 28240     3.0.2 x86_64 mingw32  0.10-1      US 10037
```
